### PR TITLE
Update 2_atom.md

### DIFF
--- a/prework/windows/2_atom.md
+++ b/prework/windows/2_atom.md
@@ -25,7 +25,7 @@ Once you've verified that your `atom` shell command is functional, run the follo
 - `apm install open-in-browser minimap highlight-selected linter linter-eslint tree-view-git-status file-icons`
 
 This will install the following packages:
-1. Open In Browser: `ctrl-alt-q` hotkey to open your HTML page in the browser from Atom
+1. Open In Browser: `ctrl-shift-q` hotkey to open your HTML page in the browser from Atom
 2. Mini-Map: Installs a mini map (useful for seeing your code at a high level) in the right hand column of the editor window
 3. Highlight Selected: Highlights all instances of a word or phrase when one instance in double-clicked or cursor-highlighted
 


### PR DESCRIPTION
The Open In Browser package enables Ctrl-Shift-Q hotkey (currently written Ctrl-Alt-Q). I learned this while doing my pre-work. I initially thought the package didn't install correctly; however the terminal said it was successful, and the Highlight and Mini-Map packages worked so I figured it was something else.