### PR TITLE
adding "10.10 or higher" to git install steps

### DIFF
--- a/prework/mac/4_git.md
+++ b/prework/mac/4_git.md
@@ -24,7 +24,7 @@ If you are running:
 
 - 10.9 Mavericks: download and install this <a href="http://sourceforge.net/projects/git-osx-installer/files/git-2.5.3-intel-universal-mavericks.dmg/download" target="_blank">git-*-mavericks</a>
 
-- 10.10 Yosemite: continue below
+- 10.10 Yosemite or higher: continue below
 
 **NOTE:** You will need to change your install permissions to be able to install Git. The installer will prompt you to do so if necessary.
 


### PR DESCRIPTION
Looking at the git OS X installer page, it seems 10.9 Mavericks was the last to get a dedicated installer, so I'm assuming the instructions for 10.10 apply to all the subsequent versions, including the current version 10.12

List of dedicated installers: https://sourceforge.net/projects/git-osx-installer/files/