### PR TITLE
Fixing broken Windows links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you are completely new to coding, consider completing <a href="https://www.co
 
   - [Mac OS X](prework/mac/1_terminal.md)
   - [Ubuntu](prework/ubuntu/1_terminal.md)
-  - [Windows with Git Bash (Legacy setup)](prework/windows.old/1_terminal.md)
+  - [Windows with Git Bash (Legacy setup)](prework/old.windows/1_terminal.md)
   - [Windows Using Windows Subsystem for Linux (New setup)](prework/windows/1_preface.md)
 
 Following completion of these Pre-work assignments, you should:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you are completely new to coding, consider completing <a href="https://www.co
   - [Mac OS X](prework/mac/1_terminal.md)
   - [Ubuntu](prework/ubuntu/1_terminal.md)
   - [Windows with Git Bash (Legacy setup)](prework/old.windows/1_terminal.md)
-  - [Windows Using Windows Subsystem for Linux (New setup)](prework/windows/1_preface.md)
+  - [Windows Using Windows Subsystem for Linux (New setup)](prework/windows/01_preface.md)
 
 Following completion of these Pre-work assignments, you should:
  - Have a terminal with a Git compatible prompt

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ If you are completely new to coding, consider completing <a href="https://www.co
 
   - [Mac OS X](prework/mac/1_terminal.md)
   - [Ubuntu](prework/ubuntu/1_terminal.md)
-  - [Windows](prework/windows/1_terminal.md)
+  - [Windows with Git Bash (Legacy setup)](prework/windows.old/1_terminal.md)
+  - [Windows Using Windows Subsystem for Linux (New setup)](prework/windows/1_preface.md)
 
 Following completion of these Pre-work assignments, you should:
  - Have a terminal with a Git compatible prompt


### PR DESCRIPTION
Windows link was broken. Added links to both Windows setups ATM just so they are there, but if we decide to switch fully over to WSL we can removed the old setup link.

- Fixed broken link to point to Legacy Windows setup
- Added link to New Windows Setup.

I did NOT update the WSL guide here, so this PR can be accepted quickly. I can update the guide in another PR.